### PR TITLE
Many small fixes for union bugs

### DIFF
--- a/tests/tconv.nim
+++ b/tests/tconv.nim
@@ -10,7 +10,9 @@ type
 suite "Union conversions":
   test "Conversion between inner type and union works":
     let x = 10 as union(int | float)
+    let y = [0, 1, 2] as union(array[0 .. 2, int] | int)
     check x as int == 10
+    check y as array[0 .. 2, int] == [0, 1, 2]
 
   test "Conversion between smaller union and bigger union works":
     let x = 10 as IntFloat
@@ -33,3 +35,4 @@ suite "Union conversions":
     check 10 as union(int | float) == 10
     check 4.0 as union(float | string) == 4.0
     check 10 == (10 as union(int | float))
+    check [0, 1, 2] as union(array[0 .. 2, int] | int) == [0, 1, 2]

--- a/tests/tuniontraits.nim
+++ b/tests/tuniontraits.nim
@@ -1,3 +1,4 @@
+import std/macros
 import pkg/balls
 
 import union, union/uniontraits
@@ -11,3 +12,10 @@ suite "Union type introspection":
   test "contains() for other unions":
     check union(int | float) in typedesc[union(int | float | string)]
     check union(int | float) notin typedesc[union(int | string | RootObj)]
+
+  test "isUnionTy()":
+    macro isUnionTy(x: typedesc): bool =
+      result = newLit x.isUnionTy
+
+    check isUnionTy(union(int | float))
+    check not isUnionTy(int)

--- a/tests/tunique.nim
+++ b/tests/tunique.nim
@@ -12,6 +12,3 @@ suite "Union type uniqueness":
 
   test "Union can unpack typeclasses":
     check union(SomeFloat | int) is union(int | float | float32 | float64)
-
-  test "Union of one type is itself":
-    check union(int | int | int | int) is int

--- a/union/ortraits.nim
+++ b/union/ortraits.nim
@@ -56,17 +56,18 @@ func `==`*(a, b: OrTy): bool =
   result = a.numTypes == b.numTypes and b in a
 
 proc add*(o: OrTy, n: NimNode) =
-  ## Add type `n` into `o` without creating duplicates.
+  ## Add type instantiation of `n` into `o` without creating duplicates.
   if n notin o:
-    o.NimNode.add n
+    o.NimNode.add getTypeInst(n)
 
 proc add*(o: OrTy, an: openArray[NimNode]) =
-  ## Add all types in array `an` to `o` without creating duplicates.
+  ## Add all instantiation of types in array `an` to `o` without creating
+  ## duplicates.
   for n in an.items:
     o.add n
 
 func add*(o: OrTy, n: OrTy) =
-  ## Add all types in `n` to `o` without creating duplicates.
+  ## Add all instantiation of types in `n` to `o` without creating duplicates.
   for typ in n.types:
     o.add copy(typ)
 

--- a/union/uniontraits.nim
+++ b/union/uniontraits.nim
@@ -94,7 +94,7 @@ func isUnionTy*(n: NimNode): bool =
   ## Returns whether `n` type is an Union.
   ##
   ## Outside of macros, `x is Union` can be used to match for Union type.
-  isNil getUnionType(n)
+  not isNil getUnionType(n)
 
 proc recCase(u: UnionTy): NimNode =
   ## Returns the case part of the object declaration.


### PR DESCRIPTION
- Fixed usage of `union` with arrays.
- Fixed error messages for `union(singleType)`.
- Blocked `union(int | int)`, as its likely that the user made an error rather than intended.