### PR TITLE
implements a macro for easy union construction from expression

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,10 +20,26 @@ proc search[T, U](x: T, needle: U): auto =
 
   let idx = find(x, needle)
   if idx >= 0:
-    result <- x[idx] # sugar for assigning without converting via `as`
+    result <- x[idx] # sugar for assignment without conversion
 
 assert [1, 2, 42, 20, 1000].search(10) of None
 assert [1, 2, 42, 20, 1000].search(42) as int == 42
+# For `==`, no explicit conversion is necessary
+assert [1, 2, 42, 20, 1000].search(42) == 42
+# Types that are not active at the moment will simply be treated as not equal
+assert [1, 2, 42, 20, 1000].search(1) != None()
+
+proc `{}`[T](x: seq[T], idx: Natural): auto =
+  ## An array accessor for seq[T] but doesn't raise if the index is not there
+  # Using makeUnion, an expression may return more than one type
+  makeUnion:
+    if idx in 0 ..< x.len:
+      x[idx]
+    else:
+      None()
+
+assert @[1]{2} of None
+assert @[42]{0} == 42
 ```
 
 See the [documentation][0] for more information on features and limitations of

--- a/tests/tmaker.nim
+++ b/tests/tmaker.nim
@@ -1,0 +1,95 @@
+import pkg/balls
+
+import union
+
+suite "makeUnion() tests":
+  test "unionTail is present in makeUnion":
+    let x = makeUnion:
+      if true:
+        unionTail(10)
+      else:
+        [1, 2, 3]
+
+    check x == 10
+
+  test "if expression":
+    let x = makeUnion:
+      if true:
+        10
+      elif false:
+        4.2
+      else:
+        "string"
+
+    check x is union(int | float | string)
+    check x == 10
+
+  test "block expression":
+    let x = makeUnion:
+      block:
+        if true:
+          10
+        elif false:
+          4.2
+        else:
+          "string"
+
+    check x is union(int | float | string)
+    check x == 10
+
+  test "pragma block expression":
+    let x = makeUnion:
+      {.line: instantiationInfo(0).}:
+        if true:
+          10
+        elif false:
+          4.2
+        else:
+          "string"
+
+    check x is union(int | float | string)
+    check x == 10
+
+  test "when expression":
+    let x = makeUnion:
+      when false:
+        [1, 2, 3, 4]
+      else:
+        if true:
+          @[1, 2, 3, 4]
+        else:
+          true
+
+    check x is union(seq[int] | bool)
+    check x == @[1, 2, 3, 4]
+
+  test "case expression":
+    let x = makeUnion:
+      case 10
+      of 1, 3, 6, 8:
+        RootObj()
+      of 2, 7, 4, 5:
+        [4, 2]
+      elif false:
+        RootRef()
+      elif true:
+        42
+      else:
+        @["string"]
+
+    check x is union(RootObj | array[2, int] | RootRef | int | seq[string])
+    check x == 42
+
+  test "try expression":
+    let x = makeUnion:
+      try:
+        RootObj()
+      except ValueError:
+        [4, 2]
+      except KeyError:
+        RootRef()
+      except:
+        42
+
+    check x is union(RootObj | array[2, int] | RootRef | int)
+    check x == RootObj()


### PR DESCRIPTION
`makeUnion` is a versitle macro allowing an expression that returns more
than one type be turned into an union type.