### PR TITLE
fix `of` operator for checking union overlapping

### DIFF
--- a/tests/tof.nim
+++ b/tests/tof.nim
@@ -37,3 +37,10 @@ suite "`of` operator test":
 
     var y = float(1.0) as union(int | B[float])
     check y of B[float]
+
+  test "`of` works for union types":
+    var x = 10 as union(int | float)
+
+    check not(x of union(float | string))
+    check x of union(int | string)
+    check x of typeof(x)

--- a/union.nim
+++ b/union.nim
@@ -84,7 +84,7 @@ macro `of`*[U: Union](x: U, T: typedesc): bool =
     # $ is used for `U` because it's a typedesc (the value not the node) in this context
     error "type <" & repr(T) & "> is not a part of <" & $U & ">", T
 
-macro `of`*(x: Union, T: typedesc[Union]): bool =
+macro `of`*[U, V: Union](x: U, T: typedesc[V]): bool =
   ## Returns whether the union `x` is having a value convertible to union `T`
   let
     union = x.getUnionType()
@@ -99,8 +99,9 @@ macro `of`*(x: Union, T: typedesc[Union]): bool =
       newLit false
     else:
       # Create a set of enum corresponding to the intersection
-      let enums = newNimNode(nnkCurlyExpr)
-      enums.add intersect
+      let enums = newNimNode(nnkCurly)
+      for typ in intersect:
+        enums.add copy union.getVariant(typ).get.enm
 
       # Produce the check expression
       infix(newCall(bindSym"currentType", x), bindSym"in", enums)


### PR DESCRIPTION
- Changed the signature so that more than one Union types can be bound.
- Re-implemented set construction for comparing union current type.