### PR TITLE
union/typeutils: workaround for generic parameters

### DIFF
--- a/tests/tgenerics.nim
+++ b/tests/tgenerics.nim
@@ -34,8 +34,15 @@ suite "generic unions test":
       else:
         check false, "this branch should not run"
 
+    proc foobar[T, U](x: union(T | U)): T =
+      if x of T:
+        result = x as T
+      else:
+        check false, "this branch should not run"
+
     check foo(10) is union(int | None)
     check bar[float](4.2 as union(float | None)) is float
+    check foobar[int, float](10 as union(float | int)) is int
 
   test "nested generic union within proc definition":
     skip "Not working":

--- a/union/typeutils.nim
+++ b/union/typeutils.nim
@@ -57,6 +57,20 @@ func newTypedesc*(n: NimNode): NimNode =
   nnkBracketExpr.newTree(bindSym"typedesc", copy(n))
 
 func sameType*(a, b: NimNode): bool =
-  ## A variant of sameType to workaround https://github.com/nim-lang/Nim/issues/18867
+  ## A variant of sameType to workaround:
+  ##
+  ## * https://github.com/nim-lang/Nim/issues/18867
+  ##
+  ## * https://github.com/nim-lang/Nim/issues/19072
   {.warning: "compiler bug workaround; see https://github.com/nim-lang/Nim/issues/18867".}
-  macros.sameType(a, b) or macros.sameType(b, a)
+  if macros.sameType(a, b) or macros.sameType(b, a):
+    {.warning: "compiler bug workaround; see https://github.com/nim-lang/Nim/issues/19072".}
+    # In case the types are generic parmeters
+    if a.typeKind == ntyGenericParam and b.typeKind == ntyGenericParam:
+      # The result will be whether they are the same symbol. This is due to
+      # sameType() treating uninstantiated generics to be the same.
+      a == b
+    else:
+      true
+  else:
+    false


### PR DESCRIPTION
Nim's `sameType` currently considers two generic parameters to be the
same when they are uninstantiated.

Ref nim-lang/Nim#19072