### PR TITLE
union: add a macro to dispatch over possible union variants

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,30 @@ proc `{}`[T](x: seq[T], idx: Natural): union(T | None) =
 
 assert @[1]{2} of None
 assert @[42]{0} == 42
+
+import json
+
+# With unpack(), dispatching based on the union type at runtime is possible!
+var x = 42 as union(int | string)
+
+block:
+  let j =
+    unpack(x):
+      # The unpacked variable name is `it` by default
+      %it
+
+  assert j.kind == JInt
+
+x <- "string"
+
+block:
+  let j =
+    # You can give the unpacked variable a different name via the second
+    # parameter, too.
+    unpack(x, upk):
+      %upk
+
+  assert j.kind == JString
 ```
 
 See the [documentation][0] for more information on features and limitations of

--- a/tests/tconv.nim
+++ b/tests/tconv.nim
@@ -42,3 +42,34 @@ suite "Union conversions":
       A[T] = T
 
     check A[float](1.0) as union(int | float) == 1.0
+
+  test "unpack() correctly dispatches":
+    var x: union(int | float)
+    x <- 10
+
+    unpack(x, upk):
+      check upk is int
+
+    x <- 1.0
+    unpack(x):
+      check it is float
+
+  test "when can be used in unpack body":
+    for i in 1 .. 4:
+      var x = makeUnion:
+        if i mod 2 == 0:
+          10
+        else:
+          1.0
+
+      unpack(x, upk):
+        if i mod 2 == 0:
+          when upk is int:
+            discard
+          else:
+            fail "This branch expects union to be int"
+        else:
+          when upk is float:
+            discard
+          else:
+            fail "This branch expects union to be float"


### PR DESCRIPTION
This enables union to be easily adapted to various generic serializing
functions, like json.%

Added to help tandy on matrix solves their problem.

Idea stolen from @beef331