### PR TITLE
uniontraits: add sameType borrows for UnionTy

### DIFF
--- a/union/uniontraits.nim
+++ b/union/uniontraits.nim
@@ -36,6 +36,10 @@ func `==`*(a: typeof(nil), b: UnionTy): bool {.borrow.}
   ## Allow comparing an UnionTy with nil
 func isNil*(u: UnionTy): bool {.borrow.}
   ## Allow comparing an UnionTy with nil
+func sameType*(a: NimNode, b: UnionTy): bool {.borrow.}
+  ## Allow comparing the type of a node with UnionTy
+func sameType*(a: UnionTy, b: NimNode): bool {.borrow.}
+  ## Allow comparing the type of a node with UnionTy
 
 func inherits(n: NimNode): NimNode =
   ## If `n` is a nnkObjectTy, returns the inherited type.


### PR DESCRIPTION
We got away with not having these due to a Nim bug that allowed `UnionTy`
to be transparently converted to `NimNode` /outside/ of this module.

Reported-by: @tandy-1000