### PR TITLE
Use taskRequires for balls when supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           path: nim
           version: ${{ matrix.branch }}
 
+      - name: Install dependencies
+        run: nimble install -y --depsOnly
+
       - name: Run tests
         run: nimble test -y
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
           path: nim
           version: ${{ matrix.branch }}
 
-      - name: Install dependencies
-        run: nimble install -y --depsOnly
-
       - name: Run tests
         run: nimble test -y
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: nimble install -y --depsOnly
 
       - name: Run tests
-        run: nimble test
+        run: nimble test -y
 
       - name: Build docs
         shell: bash

--- a/union.nimble
+++ b/union.nimble
@@ -13,6 +13,7 @@ when compiles(taskRequires):
   taskRequires "test", "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
 else:
   requires "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
+  before test: exec "nimble install -y --depsOnly"
 
 task test, "Run test suite":
   when defined(windows):

--- a/union.nimble
+++ b/union.nimble
@@ -13,7 +13,6 @@ when compiles(taskRequires):
   taskRequires "test", "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
 else:
   requires "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
-  before test: exec "nimble install -y --depsOnly"
 
 task test, "Run test suite":
   when defined(windows):

--- a/union.nimble
+++ b/union.nimble
@@ -9,7 +9,7 @@ license       = "MIT"
 
 requires "nim >= 1.5.1"
 
-when compiles(taskRequires):
+when declared(taskRequires):
   taskRequires "test", "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
 else:
   requires "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"

--- a/union.nimble
+++ b/union.nimble
@@ -8,7 +8,11 @@ license       = "MIT"
 # Dependencies
 
 requires "nim >= 1.5.1"
-requires "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
+
+when compiles(taskRequires):
+  taskRequires "test", "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
+else:
+  requires "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
 
 task test, "Run test suite":
   when defined(windows):


### PR DESCRIPTION
Nimble added task-level dependencies recently, so when it's supported you can use that instead of always requiring balls.