### PR TITLE
uniontraits: remove RootObj from inheritance chain

### DIFF
--- a/union.nimble
+++ b/union.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.5"
+version       = "0.2.0"
 author        = "Leorize"
 description   = "Anonymous unions in Nim"
 license       = "MIT"

--- a/union/uniontraits.nim
+++ b/union/uniontraits.nim
@@ -13,10 +13,11 @@ import std/options
 import typeutils
 
 type
-  Union*[T] {.pure.} = object of RootObj
+  Union*[T] {.pure, inheritable.} = object
     ## Base type of which all unions inherit from.
     ##
     ## It has no properties other than being a typeclass for matching unions.
+    empty: byte ## Empty field, used to appease codegen
 
   UnionTy* = distinct NimNode
     ## A distinct NimNode representing the type of an Union object.


### PR DESCRIPTION
Inheriting from RootObj adds an 8-byte RTTI tag, which we do not
want as we are managing this data ourselves.

With this change the overhead should drop from 16 bytes to 8 bytes
(2 bytes from tag, the rest is padding) for most unions.